### PR TITLE
Update Adafruit_MotorShield.cpp because of a WDT problem in it.

### DIFF
--- a/Adafruit_MotorShield.cpp
+++ b/Adafruit_MotorShield.cpp
@@ -234,6 +234,8 @@ void Adafruit_StepperMotor::step(uint16_t steps, uint8_t dir,  uint8_t style) {
     //Serial.println("step!"); Serial.println(uspers);
     ret = onestep(dir, style);
     delayMicroseconds(uspers);
+    //solve WDT problem with the ESP8266 with a large amount of steps: This gives time to perform other tasks like the ESP8266 WiFi:
+    delay(0);
   }
 }
 


### PR DESCRIPTION
- **Just added delay(0) after delayMicroseconds(uspers)**
- **Only necessary for the ESP8266 I think** 
- **Tested several times and the problem seems solved.** 

A WatchDogTimer problem arises with the ESP8266 when the amount of steps is larger than 100. Than the ESP8266 resets to avoid WiFi problems.
Adding a delay(0) command solves the problem to give the processor a chance to run some internal WiFi code in time.
