### PR TITLE
Update to AdaFruit _Motor_Shield_V2_library

### DIFF
--- a/Adafruit_MotorShield.cpp
+++ b/Adafruit_MotorShield.cpp
@@ -234,6 +234,10 @@ void Adafruit_StepperMotor::step(uint16_t steps, uint8_t dir,  uint8_t style) {
     //Serial.println("step!"); Serial.println(uspers);
     ret = onestep(dir, style);
     delayMicroseconds(uspers);
+    //Following line ""delay(0)"" is added because of the ESP8266 giving WatchDogTimer error that's software resetting the ESP8266
+    //to avoid problems with WiFi. 
+    //The delay gives the chance to the processor to perform the necessary WiFi tasks in between when needed. 
+    delay(0);
   }
 }
 


### PR DESCRIPTION
- *\*   With the default steppertest example in the AdaFruit-lib and the ESP8266 there's a problem that a WDT error arises if more than 100 steps are transmitted at once:

delay(0) is added because otherwise the ESP8266 giving a WatchDogTimer error software resetting the ESP8266 to avoid problems with WiFi. 
The delay gives the chance to the processor to perform the necessary WiFi tasks in between when needed. **
- **Maybe only for the ESP8266, but it doesn't harm other processors**
- **The problem could every time being replicated and I ran many tests with the stepper and the problem seems definitely solved**
